### PR TITLE
デザインの修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -114,3 +114,8 @@ header {
 .small-goal-input {
   width: 50%
 }
+
+.custom-title {
+  @extend .is-size-4;
+  @extend .my-4;
+}

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-h2.is-size-4.my-4
+h2.custom-title
   = t('.title',
     resource: devise_i18n_fix_model_name_case(resource.model_name.human,
     i18n_key: 'registrations.edit.title'))

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -1,4 +1,4 @@
-h2.is-size-4
+h2.is-size-4.my-4
   = t('.title',
     resource: devise_i18n_fix_model_name_case(resource.model_name.human,
     i18n_key: 'registrations.edit.title'))

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,4 +1,4 @@
-h2.is-size-4
+h2.is-size-4.my-4
   = t('.sign_up')
 .mx-3.mt-3
   = form_for(resource, as: resource_name,

--- a/app/views/devise/registrations/new.html.slim
+++ b/app/views/devise/registrations/new.html.slim
@@ -1,4 +1,4 @@
-h2.is-size-4.my-4
+h2.custom-title
   = t('.sign_up')
 .mx-3.mt-3
   = form_for(resource, as: resource_name,

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,4 +1,4 @@
-h2.is-size-4.my-4
+h2.custom-title
   = t('.sign_in')
 .mx-3.mt-3
   = form_for(resource, as: resource_name,

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,4 +1,4 @@
-h2.is-size-4.mt-3
+h2.is-size-4.my-4
   = t('.sign_in')
 .mx-3.mt-3
   = form_for(resource, as: resource_name,

--- a/app/views/goals/edit.html.slim
+++ b/app/views/goals/edit.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4 目標編集
+h3.is-size-4.my-4 目標編集
 = link_to '戻る', :back
 div [data-controller='small-goal color'
      data-small-goal-count-value="#{@goal.small_goals.count}"]

--- a/app/views/goals/edit.html.slim
+++ b/app/views/goals/edit.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4.my-4 目標編集
+h3.custom-title 目標編集
 = link_to '戻る', :back
 div [data-controller='small-goal color'
      data-small-goal-count-value="#{@goal.small_goals.count}"]

--- a/app/views/goals/index.html.slim
+++ b/app/views/goals/index.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4.my-4 目標一覧
+h3.custom-title 目標一覧
 = link_to new_goal_path,
   class: 'button add-button is-success is-light is-size-5 p-5' do
   i.fa-regular.fa-square-plus 目標の作成

--- a/app/views/goals/index.html.slim
+++ b/app/views/goals/index.html.slim
@@ -6,10 +6,10 @@ ul
   - @goals.each_with_index do |goal, i|
     li.box = link_to goal_path(goal) do
       p
-        span class="#{goal.status[:class]}"
+        span class="#{goal.status[:class]} mr-3"
           = goal.status[:text]
         = " #{goal.title}"
-      table.calendar-line
+      table.calendar-line.mt-2
         tr
           - @calendars[i].each do |date|
             td style="#{ date[:style] }" class="#{ date[:class] }"

--- a/app/views/goals/index.html.slim
+++ b/app/views/goals/index.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4 目標一覧
+h3.is-size-4.my-4 目標一覧
 = link_to new_goal_path,
   class: 'button add-button is-success is-light is-size-5 p-5' do
   i.fa-regular.fa-square-plus 目標の作成

--- a/app/views/goals/new.html.slim
+++ b/app/views/goals/new.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4 目標新規作成
+h3.is-size-4.my-4 目標新規作成
 = link_to '戻る', :back
 div [data-controller='small-goal color'
      data-small-goal-count-value="#{@goal.small_goals.count}"]

--- a/app/views/goals/new.html.slim
+++ b/app/views/goals/new.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4.my-4 目標新規作成
+h3.custom-title 目標新規作成
 = link_to '戻る', :back
 div [data-controller='small-goal color'
      data-small-goal-count-value="#{@goal.small_goals.count}"]

--- a/app/views/goals/show.html.slim
+++ b/app/views/goals/show.html.slim
@@ -1,7 +1,7 @@
 - content_for :js do
   = javascript_import_module_tag 'bulma_modal'
-.is-flex.is-justify-content-space-between.mt-2
-  h3.is-size-4.my-4
+.is-flex.is-justify-content-space-between.my-4
+  h3.is-size-4
     = "#{@goal.title} "
     span class="#{@goal.status[:class]}"
       = @goal.status[:text]

--- a/app/views/goals/show.html.slim
+++ b/app/views/goals/show.html.slim
@@ -60,7 +60,7 @@ table.calendar-line.mt-2.mx-5
     - @reports.each do |report|
       li.ml-3
         button.js-modal-trigger.mt-2 data-target="report-modal-#{report.id}"
-          = report.target_date
+          = "#{report.target_date} #{report.content.truncate(20)}"
         .modal id="report-modal-#{report.id}"
           .modal-background
           .modal-content

--- a/app/views/goals/show.html.slim
+++ b/app/views/goals/show.html.slim
@@ -1,7 +1,7 @@
 - content_for :js do
   = javascript_import_module_tag 'bulma_modal'
 .is-flex.is-justify-content-space-between.mt-2
-  h3.is-size-4
+  h3.is-size-4.my-4
     = "#{@goal.title} "
     span class="#{@goal.status[:class]}"
       = @goal.status[:text]

--- a/app/views/reports/edit.html.slim
+++ b/app/views/reports/edit.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4.my-4 日報編集
+h3.custom-title 日報編集
 - small_goals = @goal.small_goals.order(:created_at).pluck(:title, :id)
 div data-controller='slider' data-goal-color="#{@goal.color}"
   = render('form', models: [@goal, @report], report: @report, small_goals:)

--- a/app/views/reports/edit.html.slim
+++ b/app/views/reports/edit.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4 日報編集
+h3.is-size-4.my-4 日報編集
 - small_goals = @goal.small_goals.order(:created_at).pluck(:title, :id)
 div data-controller='slider' data-goal-color="#{@goal.color}"
   = render('form', models: [@goal, @report], report: @report, small_goals:)

--- a/app/views/reports/new.html.slim
+++ b/app/views/reports/new.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4.my-4 日報作成
+h3.custom-title 日報作成
 - small_goals = @goal.small_goals.order(:created_at).pluck(:title, :id)
 div data-controller='slider' data-goal-color="#{@goal.color}"
   = render 'form', models: [@goal, @report], report: @report, small_goals:

--- a/app/views/reports/new.html.slim
+++ b/app/views/reports/new.html.slim
@@ -1,4 +1,4 @@
-h3.is-size-4 日報作成
+h3.is-size-4.my-4 日報作成
 - small_goals = @goal.small_goals.order(:created_at).pluck(:title, :id)
 div data-controller='slider' data-goal-color="#{@goal.color}"
   = render 'form', models: [@goal, @report], report: @report, small_goals:


### PR DESCRIPTION
close #19 

### ページタイトルのスペース調節
<img width="705" alt="スクリーンショット 2024-08-21 13 42 46" src="https://github.com/user-attachments/assets/62245e1f-5c2c-4c64-a9c0-b9c26c1e614b">

 ### 目標詳細画面で日報の本文の一部を表示
<img width="590" alt="スクリーンショット 2024-08-21 13 45 03" src="https://github.com/user-attachments/assets/52671c4c-ccb2-4143-a18f-5a61731de3d1">
